### PR TITLE
Prevent warning with pyyaml

### DIFF
--- a/autobuilder.py
+++ b/autobuilder.py
@@ -117,7 +117,7 @@ class ScriptBuilder(object):
             self.templates[tpl_id] = open(template, 'r').read()
 
         with open(config_path, 'r') as handle:
-            self.CONF_DATA = yaml.load(handle, Loader=yaml.FullLoader)
+            self.CONF_DATA = yaml.load(handle, Loader=yaml.safe_load)
 
         self.PROJECT_NAME = self.CONF_DATA['project_name']
         self.underlying_lib = import_module(self.CONF_DATA['module']['base_module'])

--- a/autobuilder.py
+++ b/autobuilder.py
@@ -117,7 +117,7 @@ class ScriptBuilder(object):
             self.templates[tpl_id] = open(template, 'r').read()
 
         with open(config_path, 'r') as handle:
-            self.CONF_DATA = yaml.load(handle)
+            self.CONF_DATA = yaml.load(handle, Loader=yaml.FullLoader)
 
         self.PROJECT_NAME = self.CONF_DATA['project_name']
         self.underlying_lib = import_module(self.CONF_DATA['module']['base_module'])

--- a/autobuilder.py
+++ b/autobuilder.py
@@ -117,7 +117,7 @@ class ScriptBuilder(object):
             self.templates[tpl_id] = open(template, 'r').read()
 
         with open(config_path, 'r') as handle:
-            self.CONF_DATA = yaml.load(handle, Loader=yaml.safe_load)
+            self.CONF_DATA = yaml.safe_load(handle)
 
         self.PROJECT_NAME = self.CONF_DATA['project_name']
         self.underlying_lib = import_module(self.CONF_DATA['module']['base_module'])

--- a/commands_to_rst.py
+++ b/commands_to_rst.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_dir)
 with open('.command-engine.yml', 'r') as handle:
-    CONF_DATA = yaml.load(handle, Loader=yaml.FullLoader)
+    CONF_DATA = yaml.load(handle, Loader=yaml.safe_load)
 
 # PY3K ONLY for the import.
 if 'docs_import' in CONF_DATA:

--- a/commands_to_rst.py
+++ b/commands_to_rst.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_dir)
 with open('.command-engine.yml', 'r') as handle:
-    CONF_DATA = yaml.load(handle)
+    CONF_DATA = yaml.load(handle, Loader=yaml.FullLoader)
 
 # PY3K ONLY for the import.
 if 'docs_import' in CONF_DATA:

--- a/commands_to_rst.py
+++ b/commands_to_rst.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_dir)
 with open('.command-engine.yml', 'r') as handle:
-    CONF_DATA = yaml.load(handle, Loader=yaml.safe_load)
+    CONF_DATA = yaml.safe_load(handle)
 
 # PY3K ONLY for the import.
 if 'docs_import' in CONF_DATA:


### PR DESCRIPTION
A tiny change to prevent getting a warning when using recent version of pyyaml
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)