### PR TITLE
Strip param type too

### DIFF
--- a/autobuilder.py
+++ b/autobuilder.py
@@ -352,7 +352,7 @@ class ScriptBuilder(object):
 
                 if m:
                     param_docs['__return__'] = {
-                        'type': m.group('param_type'),
+                        'type': m.group('param_type').strip(),
                         'desc': argdoc[argdoc.index(m.group('ret')) + len(m.group('ret')):].strip(),
                     }
 


### PR DESCRIPTION
Just a little problem found while testing latest code with python-chado: there was a space at the end of "None " which made the galaxy xml wrong (= expected to return json instead of nothing)